### PR TITLE
Add cache-backed wallpaper indexing

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,4 +2,4 @@ pub mod hyprpaper;
 pub mod scanner;
 
 pub use hyprpaper::set_wallpaper;
-pub use scanner::{scan_directory, scan_wallpapers_from_paths, Wallpaper};
+pub use scanner::{scan_directory, scan_wallpapers_from_paths};

--- a/src/cache/index.rs
+++ b/src/cache/index.rs
@@ -1,0 +1,214 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
+
+const INDEX_VERSION: u32 = 1;
+const INDEX_DIR: &str = "walt/index";
+const INDEX_FILE: &str = "wallpapers.json";
+const VALID_EXTENSIONS: &[&str] = &[
+    "jpg", "jpeg", "png", "gif", "bmp", "tiff", "tif", "webp", "ico", "svg", "ppm", "pgm", "pbm",
+    "pam", "hdr", "exr", "ff", "avif", "jxl",
+];
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IndexedWallpaper {
+    pub path: PathBuf,
+    pub name: String,
+    pub directory: PathBuf,
+    pub extension: String,
+    pub modified_unix_secs: u64,
+    pub file_size: u64,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct WallpaperIndexFile {
+    version: u32,
+    wallpapers: Vec<IndexedWallpaper>,
+}
+
+pub struct WallpaperIndex {
+    index_file: PathBuf,
+}
+
+impl WallpaperIndex {
+    pub fn new() -> anyhow::Result<Self> {
+        let index_dir = dirs::cache_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not find cache directory"))?
+            .join(INDEX_DIR);
+        fs::create_dir_all(&index_dir)?;
+
+        Ok(Self {
+            index_file: index_dir.join(INDEX_FILE),
+        })
+    }
+
+    pub fn load(&self, paths: &[PathBuf]) -> Vec<IndexedWallpaper> {
+        let configured_paths = canonical_path_set(paths);
+        let file = fs::read_to_string(&self.index_file)
+            .ok()
+            .and_then(|content| serde_json::from_str::<WallpaperIndexFile>(&content).ok());
+
+        let mut wallpapers = file
+            .filter(|file| file.version == INDEX_VERSION)
+            .map(|file| file.wallpapers)
+            .unwrap_or_default();
+
+        wallpapers.retain(|wallpaper| {
+            wallpaper.path.exists()
+                && canonicalize_parented(&wallpaper.path)
+                    .map(|path| starts_with_any(&path, &configured_paths))
+                    .unwrap_or(false)
+        });
+        wallpapers.sort_by(sort_by_name);
+        wallpapers
+    }
+
+    pub fn refresh(&self, paths: &[PathBuf]) -> anyhow::Result<Vec<IndexedWallpaper>> {
+        let existing_by_path = self
+            .load(paths)
+            .into_iter()
+            .map(|wallpaper| (wallpaper.path.clone(), wallpaper))
+            .collect::<HashMap<_, _>>();
+
+        let mut wallpapers = Vec::new();
+
+        for directory in paths {
+            if !directory.is_dir() {
+                continue;
+            }
+
+            for entry in WalkDir::new(directory)
+                .max_depth(2)
+                .into_iter()
+                .filter_map(|entry| entry.ok())
+            {
+                let path = entry.path();
+                if !path.is_file() || !has_valid_extension(path) {
+                    continue;
+                }
+
+                let Some(indexed) = build_indexed_wallpaper(path, existing_by_path.get(path)) else {
+                    continue;
+                };
+                wallpapers.push(indexed);
+            }
+        }
+
+        wallpapers.sort_by(sort_by_name);
+        self.save(&wallpapers)?;
+        Ok(wallpapers)
+    }
+
+    fn save(&self, wallpapers: &[IndexedWallpaper]) -> anyhow::Result<()> {
+        let payload = WallpaperIndexFile {
+            version: INDEX_VERSION,
+            wallpapers: wallpapers.to_vec(),
+        };
+        fs::write(&self.index_file, serde_json::to_vec_pretty(&payload)?)?;
+        Ok(())
+    }
+}
+
+fn build_indexed_wallpaper(
+    path: &Path,
+    cached: Option<&IndexedWallpaper>,
+) -> Option<IndexedWallpaper> {
+    let metadata = fs::metadata(path).ok()?;
+    let modified_unix_secs = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default();
+    let file_size = metadata.len();
+
+    if let Some(cached) = cached {
+        if cached.file_size == file_size && cached.modified_unix_secs == modified_unix_secs {
+            return Some(cached.clone());
+        }
+    }
+
+    let dimensions = image::image_dimensions(path).ok();
+    Some(IndexedWallpaper {
+        path: path.to_path_buf(),
+        name: path
+            .file_stem()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_default(),
+        directory: path.parent().unwrap_or_else(|| Path::new("")).to_path_buf(),
+        extension: path
+            .extension()
+            .map(|ext| ext.to_string_lossy().to_lowercase())
+            .unwrap_or_default(),
+        modified_unix_secs,
+        file_size,
+        width: dimensions.map(|(width, _)| width),
+        height: dimensions.map(|(_, height)| height),
+    })
+}
+
+fn sort_by_name(left: &IndexedWallpaper, right: &IndexedWallpaper) -> std::cmp::Ordering {
+    left.name
+        .to_lowercase()
+        .cmp(&right.name.to_lowercase())
+        .then_with(|| left.path.cmp(&right.path))
+}
+
+fn has_valid_extension(path: &Path) -> bool {
+    path.extension()
+        .map(|ext| ext.to_string_lossy().to_lowercase())
+        .map(|ext| VALID_EXTENSIONS.contains(&ext.as_str()))
+        .unwrap_or(false)
+}
+
+fn canonical_path_set(paths: &[PathBuf]) -> HashSet<PathBuf> {
+    paths.iter().filter_map(|path| fs::canonicalize(path).ok()).collect()
+}
+
+fn canonicalize_parented(path: &Path) -> Option<PathBuf> {
+    if path.exists() {
+        fs::canonicalize(path).ok()
+    } else {
+        None
+    }
+}
+
+fn starts_with_any(path: &Path, roots: &HashSet<PathBuf>) -> bool {
+    roots.iter().any(|root| path.starts_with(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_indexed_wallpaper;
+    use std::{fs, path::PathBuf, time::{SystemTime, UNIX_EPOCH}};
+
+    fn make_temp_dir() -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("walt-index-test-{unique}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn rebuilds_entry_when_file_size_changes() {
+        let root = make_temp_dir();
+        let path = root.join("sample.png");
+        fs::write(&path, b"first").expect("write first version");
+        let initial = build_indexed_wallpaper(&path, None).expect("index first");
+
+        fs::write(&path, b"second version").expect("write second version");
+        let refreshed = build_indexed_wallpaper(&path, Some(&initial)).expect("index second");
+
+        assert_ne!(initial.file_size, refreshed.file_size);
+        fs::remove_dir_all(root).expect("cleanup temp dir");
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,3 +1,5 @@
+pub mod index;
 pub mod thumbnail;
 
+pub use index::{IndexedWallpaper, WallpaperIndex};
 pub use thumbnail::ThumbnailCache;

--- a/src/cache/thumbnail.rs
+++ b/src/cache/thumbnail.rs
@@ -1,12 +1,14 @@
 use image::imageops::FilterType;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 const PREVIEW_VERSION: &str = "preview-v4";
 const PREVIEW_MAX_WIDTH: u32 = 576;
 const PREVIEW_MAX_HEIGHT: u32 = 324;
 const CACHE_DIR: &str = "walt/thumbnails";
 
+#[derive(Clone)]
 pub struct ThumbnailCache {
     cache_dir: PathBuf,
 }
@@ -58,9 +60,18 @@ impl ThumbnailCache {
         use std::hash::{Hash, Hasher};
 
         let path_str = path.to_string_lossy();
+        let metadata = fs::metadata(path).ok();
+        let size = metadata.as_ref().map(|m| m.len()).unwrap_or_default();
+        let modified = metadata
+            .and_then(|m| m.modified().ok())
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs())
+            .unwrap_or_default();
         let mut hasher = DefaultHasher::new();
         PREVIEW_VERSION.hash(&mut hasher);
         path_str.hash(&mut hasher);
+        size.hash(&mut hasher);
+        modified.hash(&mut hasher);
         format!("{:x}", hasher.finish())
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -22,8 +22,8 @@ use std::{
     thread,
 };
 
-use crate::backend::{scan_directory, scan_wallpapers_from_paths, set_wallpaper, Wallpaper};
-use crate::cache::ThumbnailCache;
+use crate::backend::{scan_directory, set_wallpaper};
+use crate::cache::{IndexedWallpaper, ThumbnailCache, WallpaperIndex};
 use crate::config::Config;
 use theme::{ThemeKind, ThemePalette};
 
@@ -46,12 +46,22 @@ struct PreviewResponse {
     protocol: anyhow::Result<StatefulProtocol>,
 }
 
+struct IndexRequest {
+    request_id: u64,
+    wallpaper_paths: Vec<PathBuf>,
+}
+
+struct IndexResponse {
+    request_id: u64,
+    wallpapers: anyhow::Result<Vec<IndexedWallpaper>>,
+}
+
 pub struct App {
     config: Config,
     theme: ThemeKind,
     theme_before_picker: ThemeKind,
     theme_return_mode: AppMode,
-    wallpapers: Vec<Wallpaper>,
+    wallpapers: Vec<IndexedWallpaper>,
     list_state: ListState,
     theme_state: ListState,
     selected_index: usize,
@@ -60,7 +70,12 @@ pub struct App {
     preview_request_id: u64,
     preview_tx: Sender<PreviewRequest>,
     preview_rx: Receiver<PreviewResponse>,
+    prewarm_tx: Sender<Vec<PathBuf>>,
     current_image: Option<StatefulProtocol>,
+    wallpaper_index: WallpaperIndex,
+    index_request_id: u64,
+    index_tx: Sender<IndexRequest>,
+    index_rx: Receiver<IndexResponse>,
     input_buffer: String,
     dir_suggestions: Vec<PathBuf>,
     suggestion_state: ListState,
@@ -71,11 +86,12 @@ impl App {
         let config = Config::new();
         let theme = ThemeKind::from_name(&config.theme_name);
         let picker = Picker::from_query_stdio()?;
-
+        let wallpaper_index = WallpaperIndex::new()?;
+        let thumbnail_cache = ThumbnailCache::new().ok();
         let wallpapers = if config.is_empty() {
             vec![]
         } else {
-            scan_wallpapers_from_paths(&config.wallpaper_paths)
+            wallpaper_index.load(&config.wallpaper_paths)
         };
 
         let mut list_state = ListState::default();
@@ -93,7 +109,9 @@ impl App {
         } else {
             AppMode::Wallpaper
         };
-        let (preview_tx, preview_rx) = spawn_preview_worker(picker, ThumbnailCache::new().ok());
+        let (preview_tx, preview_rx) = spawn_preview_worker(picker, thumbnail_cache.clone());
+        let prewarm_tx = spawn_prewarm_worker(thumbnail_cache.clone());
+        let (index_tx, index_rx) = spawn_index_worker(WallpaperIndex::new()?);
 
         let mut app = Self {
             config,
@@ -109,11 +127,20 @@ impl App {
             preview_request_id: 0,
             preview_tx,
             preview_rx,
+            prewarm_tx,
             current_image: None,
+            wallpaper_index,
+            index_request_id: 0,
+            index_tx,
+            index_rx,
             input_buffer: String::new(),
             dir_suggestions: vec![],
             suggestion_state,
         };
+
+        if !app.config.is_empty() {
+            app.request_index_refresh();
+        }
 
         if !app.wallpapers.is_empty() && app.mode == AppMode::Wallpaper {
             app.request_preview_load(0);
@@ -149,6 +176,7 @@ impl App {
     fn run_app<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> io::Result<()> {
         loop {
             self.drain_preview_updates();
+            self.drain_index_updates();
             terminal.draw(|f| self.ui(f))?;
 
             if event::poll(std::time::Duration::from_millis(16))? {
@@ -475,7 +503,7 @@ impl App {
             self.wallpapers = vec![];
             self.mode = AppMode::Setup;
         } else {
-            self.wallpapers = scan_wallpapers_from_paths(&self.config.wallpaper_paths);
+            self.wallpapers = self.wallpaper_index.load(&self.config.wallpaper_paths);
             self.list_state.select(if self.wallpapers.is_empty() {
                 None
             } else {
@@ -485,6 +513,7 @@ impl App {
             if !self.wallpapers.is_empty() {
                 self.request_preview_load(0);
             }
+            self.request_index_refresh();
         }
     }
 
@@ -771,6 +800,14 @@ impl App {
             image_path: wallpaper.path.clone(),
             area: self.preview_area,
         });
+        let prewarm_paths = self
+            .wallpapers
+            .iter()
+            .skip(index.saturating_sub(3))
+            .take(7)
+            .map(|wallpaper| wallpaper.path.clone())
+            .collect::<Vec<_>>();
+        let _ = self.prewarm_tx.send(prewarm_paths);
     }
 
     fn drain_preview_updates(&mut self) {
@@ -789,6 +826,38 @@ impl App {
         }
     }
 
+    fn request_index_refresh(&mut self) {
+        self.index_request_id = self.index_request_id.wrapping_add(1);
+        let _ = self.index_tx.send(IndexRequest {
+            request_id: self.index_request_id,
+            wallpaper_paths: self.config.wallpaper_paths.clone(),
+        });
+    }
+
+    fn drain_index_updates(&mut self) {
+        loop {
+            match self.index_rx.try_recv() {
+                Ok(response) if response.request_id == self.index_request_id => {
+                    if let Ok(wallpapers) = response.wallpapers {
+                        self.wallpapers = wallpapers;
+                        if self.wallpapers.is_empty() {
+                            self.list_state.select(None);
+                            self.selected_index = 0;
+                            self.current_image = None;
+                        } else {
+                            let max_index = self.wallpapers.len() - 1;
+                            self.selected_index = self.selected_index.min(max_index);
+                            self.list_state.select(Some(self.selected_index));
+                            self.request_preview_load(self.selected_index);
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(TryRecvError::Empty | TryRecvError::Disconnected) => break,
+            }
+        }
+    }
+
     fn apply_wallpaper(&self) -> anyhow::Result<()> {
         if let Some(wallpaper) = self.wallpapers.get(self.selected_index) {
             let path_str = wallpaper.path.to_string_lossy().to_string();
@@ -797,6 +866,27 @@ impl App {
         }
         Ok(())
     }
+}
+
+fn spawn_index_worker(index: WallpaperIndex) -> (Sender<IndexRequest>, Receiver<IndexResponse>) {
+    let (request_tx, request_rx) = mpsc::channel::<IndexRequest>();
+    let (response_tx, response_rx) = mpsc::channel::<IndexResponse>();
+
+    thread::spawn(move || {
+        while let Ok(mut request) = request_rx.recv() {
+            while let Ok(next_request) = request_rx.try_recv() {
+                request = next_request;
+            }
+
+            let wallpapers = index.refresh(&request.wallpaper_paths);
+            let _ = response_tx.send(IndexResponse {
+                request_id: request.request_id,
+                wallpapers,
+            });
+        }
+    });
+
+    (request_tx, response_rx)
 }
 
 fn spawn_preview_worker(
@@ -821,6 +911,28 @@ fn spawn_preview_worker(
     });
 
     (request_tx, response_rx)
+}
+
+fn spawn_prewarm_worker(thumbnail_cache: Option<ThumbnailCache>) -> Sender<Vec<PathBuf>> {
+    let (request_tx, request_rx) = mpsc::channel::<Vec<PathBuf>>();
+
+    thread::spawn(move || {
+        while let Ok(mut paths) = request_rx.recv() {
+            while let Ok(next_paths) = request_rx.try_recv() {
+                paths = next_paths;
+            }
+
+            let Some(cache) = thumbnail_cache.as_ref() else {
+                continue;
+            };
+
+            for path in paths {
+                let _ = cache.generate_thumbnail(path);
+            }
+        }
+    });
+
+    request_tx
 }
 
 fn build_preview_protocol(


### PR DESCRIPTION
## Summary
- add a cache-backed wallpaper index under the cache directory
- refresh the index in the background and load cached entries immediately on startup
- invalidate thumbnails when file size or modification time changes