### PR TITLE
Add preview metadata panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +213,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +242,12 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core2"
@@ -522,6 +548,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icy_sixel"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +688,16 @@ checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1461,6 +1521,7 @@ name = "walt"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "crossterm",
  "dirs",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dirs = "5.0"
 walkdir = "2.5"
 anyhow = "1.0"
 rand = "0.8"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [profile.release]
 opt-level = 3

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 mod theme;
 
+use chrono::{Local, TimeZone};
 use rand::Rng;
 use ratatui::{
     backend::{Backend, CrosstermBackend},
@@ -1108,13 +1109,18 @@ impl App {
         frame.render_widget(block, area);
         frame.render_widget(Block::default().style(theme.surface), inner);
 
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(12), Constraint::Length(7)])
+            .split(inner);
+
         if let Some(ref mut protocol) = self.current_image {
             let resize = Resize::Scale(None);
-            let render_area = center_rect(inner, protocol.size_for(&resize, inner));
+            let render_area = center_rect(layout[0], protocol.size_for(&resize, layout[0]));
             let image = StatefulImage::default().resize(resize);
             frame.render_stateful_widget(image, render_area, protocol);
         } else {
-            let content = if self.wallpapers.is_empty() {
+            let lines = if self.wallpapers.is_empty() {
                 vec![
                     Line::from(Span::styled("No wallpapers found", theme.muted)),
                     Line::from(Span::styled("Configure paths with 'p'", theme.key)),
@@ -1125,8 +1131,10 @@ impl App {
                     Line::from(Span::styled("to see preview", theme.muted)),
                 ]
             };
-            frame.render_widget(Para::new(content).alignment(Alignment::Center), inner);
+            frame.render_widget(Para::new(lines).alignment(Alignment::Center), layout[0]);
         }
+
+        self.render_metadata(frame, layout[1], theme);
     }
 
     fn render_help(&self, frame: &mut Frame, area: Rect, theme: ThemePalette) {
@@ -1259,6 +1267,52 @@ impl App {
         .block(self.themed_block(" Edit Rotation Interval ", theme))
         .alignment(Alignment::Left);
         frame.render_widget(input, popup);
+    }
+
+    fn render_metadata(&self, frame: &mut Frame, area: Rect, theme: ThemePalette) {
+        let block = self.themed_block(" Metadata ", theme);
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let Some(wallpaper) = self.current_selected_wallpaper() else {
+            frame.render_widget(
+                Para::new(Line::from(Span::styled("No wallpaper selected", theme.muted)))
+                    .alignment(Alignment::Center),
+                inner,
+            );
+            return;
+        };
+
+        let resolution = match (wallpaper.width, wallpaper.height) {
+            (Some(width), Some(height)) => format!("{width}x{height}"),
+            _ => "unknown".to_string(),
+        };
+        let lines = vec![
+            Line::from(vec![
+                Span::styled("File: ", theme.key),
+                Span::styled(wallpaper.name.clone(), theme.accent),
+            ]),
+            Line::from(vec![
+                Span::styled("Dir: ", theme.key),
+                Span::styled(wallpaper.directory.to_string_lossy().to_string(), theme.accent),
+            ]),
+            Line::from(vec![
+                Span::styled("Resolution: ", theme.key),
+                Span::styled(resolution, theme.accent),
+                Span::raw("  "),
+                Span::styled("Size: ", theme.key),
+                Span::styled(format_file_size(wallpaper.file_size), theme.accent),
+            ]),
+            Line::from(vec![
+                Span::styled("Modified: ", theme.key),
+                Span::styled(format_timestamp(wallpaper.modified_unix_secs), theme.accent),
+            ]),
+            Line::from(vec![
+                Span::styled("Format: ", theme.key),
+                Span::styled(wallpaper.extension.to_uppercase(), theme.accent),
+            ]),
+        ];
+        frame.render_widget(Para::new(lines), inner);
     }
 
     fn request_preview_load(&mut self) {
@@ -1439,4 +1493,25 @@ fn centered_rect(width_percent: u16, height: u16, area: Rect) -> Rect {
     let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
     let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
     Rect::new(x, y, popup_width, popup_height)
+}
+
+fn format_file_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+
+    if bytes as f64 >= MB {
+        format!("{:.1} MB", bytes as f64 / MB)
+    } else if bytes as f64 >= KB {
+        format!("{:.1} KB", bytes as f64 / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn format_timestamp(unix_secs: u64) -> String {
+    Local
+        .timestamp_opt(unix_secs as i64, 0)
+        .single()
+        .map(|datetime| datetime.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| unix_secs.to_string())
 }


### PR DESCRIPTION
## Summary
- split the right pane into preview and metadata sections
- show filename, directory, resolution, file size, modified time, and format
- keep the preview layout responsive in smaller terminal windows