### PR TITLE
Update README with Arch Linux installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Quick install:
 curl -fsSL https://raw.githubusercontent.com/gitfudge0/walt/main/install.sh | bash
 ```
 
-If you're on Arch:
+If you're on Arch, use your preferred AUR helper:
 
 ```sh
-yay walt-git
+yay -S walt-git
 ```
 
 This installs `walt` to `~/.local/bin/walt`.


### PR DESCRIPTION
Added installation instructions for Arch Linux users. Using the [AUR](https://aur.archlinux.org/packages/walt-git) package.