### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: '[Bug]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the details below.
+
+  - type: input
+    id: version
+    attributes:
+      label: Walt Version
+      description: Run `walt --version` to get this
+      placeholder: e.g., 0.8.0
+    validations:
+      required: true
+
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust Version
+      description: Run `rustc --version` to get this
+      placeholder: e.g., 1.75.0
+    validations:
+      required: true
+
+  - type: input
+    id: hyprland-version
+    attributes:
+      label: Hyprland Version
+      description: Run `hyprctl version` to get this
+      placeholder: e.g., 0.35.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Interface
+      description: Which interface were you using?
+      options:
+        - TUI (Terminal)
+        - GUI (Desktop)
+        - CLI Commands
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal Emulator
+      description: If using TUI, which terminal?
+      placeholder: e.g., Ghostty, Kitty, WezTerm
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce the bug?
+      placeholder: |
+        1. Run 'walt'
+        2. Navigate to ...
+        3. Press ...
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Describe what should have happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or Error Messages
+      description: Any relevant output or error messages
+      render: shell
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I've searched existing issues and this hasn't been reported
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Walt Documentation
+    url: https://github.com/gitfudge0/walt#readme
+    about: Check the README for installation and usage instructions

--- a/.github/ISSUE_TEMPLATE/discussion.yml
+++ b/.github/ISSUE_TEMPLATE/discussion.yml
@@ -1,0 +1,46 @@
+name: Discussion
+description: Start a general discussion or ask a question
+title: '[Discussion]: '
+labels: ['question']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for general questions, discussions, or anything that doesn't fit into bug reports or feature requests.
+
+  - type: textarea
+    id: topic
+    attributes:
+      label: Topic
+      description: What would you like to discuss?
+      placeholder: |
+        - Questions about usage
+        - Architecture decisions
+        - Best practices
+        - Community topics
+        - Anything else!
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Provide more context about your question or discussion topic
+      placeholder: Explain your situation, what you've tried, or what you're curious about...
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What category does this fall under?
+      options:
+        - Usage Question
+        - Development
+        - Design/UX
+        - Performance
+        - Documentation
+        - Community
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: '[Feature]: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe your use case and the problem you're trying to solve.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve?
+      placeholder: I find it difficult to... or It would be great if...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature you'd like to see
+      placeholder: Walt could add a feature that...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Interface
+      description: Which interface should this apply to?
+      options:
+        - TUI (Terminal)
+        - GUI (Desktop)
+        - CLI Commands
+        - All of the above
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Have you considered other solutions or workarounds?
+      placeholder: I tried... or I considered...
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or examples
+      placeholder: Add any other relevant information...
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I've searched existing issues and this hasn't been requested
+          required: true


### PR DESCRIPTION
## Summary

This PR adds structured GitHub issue templates to improve issue quality and make triage easier.

## Templates Added

- **Bug Report** (`bug_report.yml`): Structured form requesting Walt version, Rust version, Hyprland version, terminal emulator, and reproduction steps
- **Feature Request** (`feature_request.yml`): Focuses on problem/solution description with interface scope selection
- **Discussion** (`discussion.yml`): General questions and discussions with category selection
- **Config** (`config.yml`): Links to documentation, blank issues still enabled

## Benefits

- Ensures bug reports include all necessary version info
- Guides users to describe use cases for features
- Automatically applies labels (`bug`, `enhancement`, `question`)
- Prevents duplicate issues with checklist items
- Maintains consistency across all issues

## Notes

- All templates are optional (blank issues still enabled)
- Links to README for common questions
- Walt-specific fields for Hyprland/TUI/GUI context